### PR TITLE
Fix wording

### DIFF
--- a/inc/meta-fields.inc
+++ b/inc/meta-fields.inc
@@ -56,7 +56,7 @@ class MetaFields {
 	public function add_fields($fields){
 
 		/**
-		 * lizenses selection
+		 * licenses selection
 		 */
 		$list = CreativeCommon::getList();
 		$selections = array();
@@ -67,7 +67,7 @@ class MetaFields {
 			);
 		}
 		$fields[Plugin::META_LICENSE] = array(
-			'label' => __('Lizense','media_license'),
+			'label' => __('License','media_license'),
 			'input' => 'select',
 			'value' => '',
 			'helps' => __('Add license to caption if provided','media_license'),

--- a/languages/media_license-de_DE.po
+++ b/languages/media_license-de_DE.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 
 #: media-license.php:120
-msgid "Lizense"
+msgid "License"
 msgstr "Lizenz"
 
 #: media-license.php:123

--- a/languages/media_license.pot
+++ b/languages/media_license.pot
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 
 #: media-license.php:120
-msgid "Lizense"
+msgid "License"
 msgstr ""
 
 #: media-license.php:123


### PR DESCRIPTION
Fixes a typo (`Lizense` instead of `License`). Mo-File has to be generated still though.